### PR TITLE
CSCQVAIN-196: Automated (CI) security audit on pull requests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": ["plugin:vue/essential", "eslint:recommended"],
+  "extends": ["plugin:vue/recommended", "eslint:all"],
   "env": {
     "browser": true,
     "node": true

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log*
 
 dependency-check
 dependency-check*
+*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ yarn-error.log*
 
 # editor
 *.kate-swp
+
+dependency-check
+dependency-check*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
-os: osx
-addons:
-  homebrew:
-    - dependency-check
 language: node_js
 node_js:
   - "10"
-before_script:
-  - dependency-check --format JSON --format HTML --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1
 script:
-  - npm run build
+  - make
+  - make security

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
+os: osx
+addons:
+  homebrew:
+    - dependency-check
 language: node_js
 node_js:
   - "10"
-script: npm run build
+before_script:
+  - dependency-check --format JSON --format HTML --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1
+script:
+  - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "10"
+- '10'
 script:
-  - make
-  - make security
+- make
+- make security
+notifications:
+  flowdock:
+    secure: HajIqFFcOdQPSi6cODPGloEhPJyQOxKdRwPyVLt+h78QBKQiBqMFU11t22wq9LoRT4ZhTQq2XVpjkNw8RvIyAI9CAhcOJ1qEoDkHHfh8oMeJK916VULTIGzWbVqK4nOyoPl47qMJjabHgycCNkDFiSc+F7cfbOLhIANqdP2hiWKwiTvC1bnmFG0nQhIM4uSBkTc2s9a1hu0caB+D72i5lqa6C0/hk6AFMWpzz14foSuDKWMbT13Sy4gHHYl9DiPg6oRu9ymjh0rHCtrXKvR9rwXUnV5A+SqPMTjx5dDyGPKX5aTpImQkCEXHzFWVZINeWtTMrC8fn8HK+jGA/rK/0HxGTZ2UH8CS+fHlLO7WYxbNxv4xWauufydgd8XmRoOTjms/mVJH7874vpfU38Tbh9TZE5bykv/75N1BWaZ2Q7a6o/GADq+FVUeGVDbEMJOo0WOMOBLcax15jHElV8bz1Pcl6DMt9yMfmxEiAO3siJMnkxC4/0nkJBFZfJ+DaqZiHNIjAfznYWv4APiMAbhoSfNhpjVt0HFzHNUqTVI7vnSro53BykjNZl930vZUphYQIIt/yYuwMd9Nf1PRQczHnT/qWCRvkL1LKCPyFRZ4uYJH7cs/SrXCz97MsPo2MY8A52uc/DPLaG5ZrIGTyyuHEHGrTWQWB/WQFONvqU0cnIQ=

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 	npm run build
 
 security: dependency-check
-	./dependency-check/bin/dependency-check.sh --format JSON --format HTML --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1
+	./dependency-check/bin/dependency-check.sh --format JSON --format HTML --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1 --exclude dependency-check
 
 dependency-check:
 	curl -sLS "https://bintray.com/jeremy-long/owasp/download_file?file_path=dependency-check-5.0.0-release.zip" > dependency-check-5.0.0-release.zip

--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ lint:
 audit:
 	@echo
 	@echo "== npm audit > . =="
-	-@npm audit --parseable
+	-@npm audit
 	@echo "== Completed npm audit > . =="
 	@echo
 	@echo "== npm audit > vendor/validator =="
-	-@cd vendor/validator && npm audit --parseable
+	-@cd vendor/validator && npm audit
 	@echo "== Completed npm audit > vendor/validator =="
 	@echo
 	@echo "== npm audit > vendor/json-pointer =="
-	-@cd vendor/json-pointer && npm audit --parseable
+	-@cd vendor/json-pointer && npm audit
 	@echo "== Completed npm audit > vendor/json-pointer =="
 	@echo
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+all:
+	npm run build
+
+security: dependency-check
+	./dependency-check/bin/dependency-check.sh --format JSON --format HTML --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1
+
+dependency-check:
+	curl -sLS "https://bintray.com/jeremy-long/owasp/download_file?file_path=dependency-check-5.0.0-release.zip" > dependency-check-5.0.0-release.zip
+	unzip dependency-check-5.0.0-release.zip

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ all:
 
 security: dependency-check
 	./dependency-check/bin/dependency-check.sh --format JSON --format HTML --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1 --exclude dependency-check
+	make audit
+
+audit:
+	npm audit
+	cd vendor/validator && npm audit
+	cd vendor/json-pointer && npm audit
 
 dependency-check:
 	curl -sLS "https://bintray.com/jeremy-long/owasp/download_file?file_path=dependency-check-5.0.0-release.zip" > dependency-check-5.0.0-release.zip

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 all:
+	cd vendor/validator && npm install
+	cd vendor/json-pointer && npm install
+	npm install
 	npm run build
 
 security: dependency-check

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 
-all:
+all: lint
 	@echo
 	@echo "== downloading all npm packages =="
 	@cd vendor/validator && npm install --no-audit
@@ -19,6 +19,9 @@ security: dependency-check
 	-@./dependency-check/bin/dependency-check.sh --format JSON --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1 --exclude dependency-check --disableJar --disableNugetconf --disableNuspec --disableAssembly
 	@echo "== Completed OWASP Dependency Check =="
 	@make audit
+
+lint:
+	-@./node_modules/.bin/eslint src  --ext .js
 
 audit:
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,44 @@
+SHELL:=/bin/bash
+
 all:
-	cd vendor/validator && npm install
-	cd vendor/json-pointer && npm install
-	npm install
-	npm run build
+	@echo
+	@echo "== downloading all npm packages =="
+	@cd vendor/validator && npm install --no-audit
+	@cd vendor/json-pointer && npm install --no-audit
+	@npm install --no-audit
+	@echo "== Completed downloading all npm packages =="
+	@echo
+	@echo "== Build project =="
+	@npm run build
+	@echo "== Completed Build project =="
+	@echo
 
 security: dependency-check
-	./dependency-check/bin/dependency-check.sh --format JSON --format HTML --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1 --exclude dependency-check
-	make audit
+	@echo
+	@echo "== OWASP Dependency Check =="
+	-@./dependency-check/bin/dependency-check.sh --format JSON --scan . --enableExperimental --disableOssIndex --prettyPrint --failOnCVSS 1 --exclude dependency-check --disableJar --disableNugetconf --disableNuspec --disableAssembly
+	@echo "== Completed OWASP Dependency Check =="
+	@make audit
 
 audit:
-	-npm audit
-	-cd vendor/validator && npm audit
-	-cd vendor/json-pointer && npm audit
+	@echo
+	@echo "== npm audit > . =="
+	-@npm audit --parseable
+	@echo "== Completed npm audit > . =="
+	@echo
+	@echo "== npm audit > vendor/validator =="
+	-@cd vendor/validator && npm audit --parseable
+	@echo "== Completed npm audit > vendor/validator =="
+	@echo
+	@echo "== npm audit > vendor/json-pointer =="
+	-@cd vendor/json-pointer && npm audit --parseable
+	@echo "== Completed npm audit > vendor/json-pointer =="
+	@echo
 
 dependency-check:
-	curl -sLS "https://bintray.com/jeremy-long/owasp/download_file?file_path=dependency-check-5.0.0-release.zip" > dependency-check-5.0.0-release.zip
-	unzip dependency-check-5.0.0-release.zip
+	@echo
+	@echo "== Downloading dependency check =="
+	@curl -sLS "https://bintray.com/jeremy-long/owasp/download_file?file_path=dependency-check-5.0.0-release.zip" > dependency-check-5.0.0-release.zip
+	@unzip dependency-check-5.0.0-release.zip
+	@echo "== Completed Downloading dependency check =="
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ security: dependency-check
 	make audit
 
 audit:
-	npm audit
-	cd vendor/validator && npm audit
-	cd vendor/json-pointer && npm audit
+	-npm audit
+	-cd vendor/validator && npm audit
+	-cd vendor/json-pointer && npm audit
 
 dependency-check:
 	curl -sLS "https://bintray.com/jeremy-long/owasp/download_file?file_path=dependency-check-5.0.0-release.zip" > dependency-check-5.0.0-release.zip

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
 SHELL:=/bin/bash
 
-all: lint
+all:
+	@echo
+	@echo "== Build project =="
+	@npm run build
+	@echo "== Completed Build project =="
+	@echo
+
+node_modules:
 	@echo
 	@echo "== downloading all npm packages =="
 	@cd vendor/validator && npm install --no-audit
 	@cd vendor/json-pointer && npm install --no-audit
 	@npm install --no-audit
 	@echo "== Completed downloading all npm packages =="
-	@echo
-	@echo "== Build project =="
-	@npm run build
-	@echo "== Completed Build project =="
 	@echo
 
 security: dependency-check
@@ -21,7 +24,7 @@ security: dependency-check
 	@make audit
 
 lint:
-	-@./node_modules/.bin/eslint src  --ext .js
+	-@./node_modules/.bin/eslint --ext .js --ignore-path ./src/schemas/*.js src
 
 audit:
 	@echo
@@ -45,3 +48,5 @@ dependency-check:
 	@unzip dependency-check-5.0.0-release.zip
 	@echo "== Completed Downloading dependency check =="
 	@echo
+
+check: node_modules lint security audit


### PR DESCRIPTION
ADD: Makefile for Travis CI use.
ADD: Flowdock integration.
ADD: OWASP Dependency Check
ADD: npm audit
ADD: make lint, which uses already installed eslint.
ADD: make security
EDIT: .travis.yml
NEW: Makefile

Currently the codebase has so many issues that the errors are ignored. Those needs to be handled in separate PR where the error ignoring will be also removed from Makefile.

The Flowdock API Token can be found from:
https://www.flowdock.com/account/tokens

Then the *encrypted* API Token can be updated with:
`travis encrypt api_token --add notifications.flowdock`
https://docs.travis-ci.com/user/notifications/#configuring-flowdock-notifications