### PR TITLE
CSCQVAIN-307: Pagination fix

### DIFF
--- a/src/views/Datasets.vue
+++ b/src/views/Datasets.vue
@@ -26,7 +26,7 @@
 					:per-page="datasetsView.perPage"
 					:total-rows="datasetsView.filteredCount"
 					aria-controls="dataset-list"
-					@change="setPage"
+					@input="setPage"
 				/>
 
 				<div class="per-page">


### PR DESCRIPTION
Call setPage also when b-pagination changes its page programmatically. Was initially worried that this could cause an infinite loop, but b-pagination only emits the `@input` event when the page actually changes.