### PR TITLE
Version bump v0.10.2 fix for package-lock.json.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qvain-js",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
the package-lock.json was not updated. We should use always `npm version` command to avoid issues like this.