### PR TITLE
CSCQVAIN-228: ADD: Filepicker should not show folder identifier. Rather only files should show

### DIFF
--- a/src/filebrowser/Browser.vue
+++ b/src/filebrowser/Browser.vue
@@ -30,6 +30,13 @@
 				<span v-else>{{data.item.name}}</span>
 			</template>
 
+			<template
+				slot="identifier"
+				slot-scope="data"
+			>
+				{{ data.item.type !== 'files' ? '' : data.item.identifier }}
+			</template>
+			
 			<template slot="actions" slot-scope="data">
 				<b-btn variant="primary" v-if="data.item.type === 'files'" size="sm" @click.stop="data.toggleDetails" class="mr-2">{{ data.detailsShowing ? 'Hide' : 'Show'}} PAS metadata</b-btn>
 			</template>


### PR DESCRIPTION
Currently identifiers are shown both to files and folders. after this fix it won't be shown to folders in File Picker 