### PR TITLE
CSCQVAIN-463: Fixed "make lint" target to scan vue files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ security: node_modules dependency-check
 	@echo "== Completed OWASP Dependency Check =="
 
 lint: node_modules
-	-@./node_modules/.bin/eslint --ext .js --ignore-path ./src/schemas/*.js src
+	-@./node_modules/.bin/eslint --ext .js,.vue --ignore-path ./src/schemas/*.js src
 
 audit: node_modules
 	@echo


### PR DESCRIPTION
The JavaScript which was written inside vue files was not scanned.