### PR TITLE
CSCFAIRMETA-418: Fix MetaxRecord error not getting cleared

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -340,6 +340,10 @@ export default new Vuex.Store({
 		},
 	},
 	actions: {
+		clearMetaxRecord({ commit }) {
+			commit('setMetaxRecordError', null)
+			commit('setMetaxRecord', null)
+		},
 		async	fetchMetaxRecord({ state, commit }) {
 			if (state.metadata.metaxIdentifier) {
 				try {
@@ -357,7 +361,7 @@ export default new Vuex.Store({
 					commit('setMetaxRecord', null)
 				}
 			} else {
-				if (state.metaxRecord) {
+				if (state.metaxRecord || state.metaxRecordError) {
 					commit('setMetaxRecordError', null)
 					commit('setMetaxRecord', null)
 				}

--- a/src/store.js
+++ b/src/store.js
@@ -362,8 +362,7 @@ export default new Vuex.Store({
 				}
 			} else {
 				if (state.metaxRecord || state.metaxRecordError) {
-					commit('setMetaxRecordError', null)
-					commit('setMetaxRecord', null)
+					commit('clearMetaxRecord')
 				}
 			}
 		},

--- a/src/store.js
+++ b/src/store.js
@@ -177,6 +177,10 @@ export default new Vuex.Store({
 		setDeletedItem(state, payload) {
 			Vue.set(state.deletedItems[payload.category], payload.identifier, payload.val)
 		},
+		clearMetaxRecord(state) {
+			Vue.set(state, 'metaxRecord', null)
+			Vue.set(state, 'metaxRecordError', null)
+		},
 		setMetaxRecord(state, payload) {
 			Vue.set(state, 'metaxRecord', payload)
 		},
@@ -340,10 +344,6 @@ export default new Vuex.Store({
 		},
 	},
 	actions: {
-		clearMetaxRecord({ commit }) {
-			commit('setMetaxRecordError', null)
-			commit('setMetaxRecord', null)
-		},
 		async	fetchMetaxRecord({ state, commit }) {
 			if (state.metadata.metaxIdentifier) {
 				try {

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -760,7 +760,7 @@ export default {
 			this.$store.commit('loadHints', {})
 			this.$store.commit('loadData', undefined)
 			this.$store.commit('resetMetadata')
-			this.$store.dispatch('clearMetaxRecord')
+			this.$store.commit('clearMetaxRecord')
 		},
 		async reloadDataset() {
 			this.confirmUnsavedChanges("Do you want to reload the dataset?", "No, I do not want to.", async value => {
@@ -777,7 +777,7 @@ export default {
 			try {
 				const { data } = await apiClient.get(`/datasets/${id}`)
 				this.$store.commit('resetMetadata')
-				this.$store.dispatch('clearMetaxRecord')
+				this.$store.commit('clearMetaxRecord')
 				this.selectedCatalog = this.getCatalogForData(data)
 				this.$store.commit('loadSchema', this.selectedCatalog.schema)
 				this.$store.commit('loadHints', this.selectedCatalog.ui)

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -250,6 +250,7 @@
 				<b-col v-if="selectedCatalog">
 					<b-form
 						:key="refreshCounter"
+						novalidate
 						@submit.prevent
 					>
 						<tab-selector
@@ -759,6 +760,7 @@ export default {
 			this.$store.commit('loadHints', {})
 			this.$store.commit('loadData', undefined)
 			this.$store.commit('resetMetadata')
+			this.$store.dispatch('clearMetaxRecord')
 		},
 		async reloadDataset() {
 			this.confirmUnsavedChanges("Do you want to reload the dataset?", "No, I do not want to.", async value => {
@@ -775,7 +777,7 @@ export default {
 			try {
 				const { data } = await apiClient.get(`/datasets/${id}`)
 				this.$store.commit('resetMetadata')
-				this.$store.commit('setMetaxRecord', null)
+				this.$store.dispatch('clearMetaxRecord')
 				this.selectedCatalog = this.getCatalogForData(data)
 				this.$store.commit('loadSchema', this.selectedCatalog.schema)
 				this.$store.commit('loadHints', this.selectedCatalog.ui)
@@ -866,7 +868,9 @@ export default {
 		updateAutocomplete() {
 			// New autocomplete values are saved when a form is submitted or the submit button is clicked.
 			// The form prevents the triggered event from reloading the page.
-			this.$refs.submit.click() // click hidden submit button
+			if (this.$refs.submit) {
+				this.$refs.submit.click() // click hidden submit button
+			}
 		},
 	},
 	beforeRouteUpdate(to, form, next) {


### PR DESCRIPTION
* Metax error in file tab did not always get cleared when changing dataset.
* Another fix: Add novalidate to dataset form to prevent error from Chrome doing its own form validation when invisible submit button is used for saving autocompletion data.